### PR TITLE
[feat] ReviewListTableViewCell UI 수정 작업 

### DIFF
--- a/Scently/Scently/Resources/Assets.xcassets/Icon/icons8-댓글-96 2.imageset/Contents.json
+++ b/Scently/Scently/Resources/Assets.xcassets/Icon/icons8-댓글-96 2.imageset/Contents.json
@@ -1,17 +1,17 @@
 {
   "images" : [
     {
-      "filename" : "icons8-댓글-96 2.png",
+      "filename" : "icons8-댓글-96 2.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "filename" : "icons8-댓글-96 2@2x.png",
+      "filename" : "icons8-댓글-96 2@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "filename" : "icons8-댓글-96 2@3x.png",
+      "filename" : "icons8-댓글-96 2@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     }

--- a/Scently/Scently/Resources/Assets.xcassets/dior 향수.imageset/Contents.json
+++ b/Scently/Scently/Resources/Assets.xcassets/dior 향수.imageset/Contents.json
@@ -1,17 +1,17 @@
 {
   "images" : [
     {
-      "filename" : "dior 향수 2.png",
+      "filename" : "dior 향수 2.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "filename" : "dior 향수 2@2x.png",
+      "filename" : "dior 향수 2@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "filename" : "dior 향수 2@3x.png",
+      "filename" : "dior 향수 2@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     }

--- a/Scently/Scently/View/Social/OOTD/OOTDDetailViewController.swift
+++ b/Scently/Scently/View/Social/OOTD/OOTDDetailViewController.swift
@@ -131,7 +131,7 @@ final class OOTDDetailViewController: UIViewController {
             self?.present(commentVC, animated: true)
         }
         
-        postContentView.configure(text: "실제 리뷰 텍스트가 여기에 들어갑니다. 매우 긴 텍스트일 수도 있고 짧을 수도 있습니다.실제 리뷰 텍스트가 여기에 들어갑니다. 매우")
+        postContentView.configure(text: "실제 리뷰 텍스트가 여기에 들어갑니다. 매우 긴 텍스트일 수도 있고 짧을 수도 있습니다.실제 리뷰 텍스트가 여기에 들어갑니다. 매우실제 리뷰 텍스트가 여기에 들어갑니다. 매우 긴 텍스트일 수도 있고 짧을 수도 있습니다.실제 리뷰 텍스트가 여기에 들어갑니다. 매우실제 리뷰 텍스트가 여기에 들어갑니다. 매우 긴 텍스트일 수도 있고 짧을 수도 있습니다.실제 리뷰 텍스트가 여기에 들어갑니다. 매우")
     }
 }
 

--- a/Scently/Scently/View/Social/OOTD/PostContentView.swift
+++ b/Scently/Scently/View/Social/OOTD/PostContentView.swift
@@ -23,13 +23,19 @@ final class PostContentView: UIView {
         return label
     }()
     
-    private let contentLabel: UILabel = {
-        let label = UILabel()
-        label.numberOfLines = 2
-        label.font = .pretendard(.regular, size: 14)
-        label.textColor = .black
-        label.isUserInteractionEnabled = true
-        return label
+    
+    private let contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.font = .pretendard(.regular, size: 14)
+        textView.textColor = .black
+        textView.backgroundColor = .clear
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.textContainer.lineFragmentPadding = 0
+        textView.textContainerInset = .zero
+        textView.textContainer.lineBreakMode = .byTruncatingTail
+        textView.textContainer.maximumNumberOfLines = 2
+        return textView
     }()
     
     private let containerView: UIView = {
@@ -47,7 +53,8 @@ final class PostContentView: UIView {
         super.init(frame: frame)
         setupUI()
         setupConstraints()
-        setupGesture()
+     //   setupGesture()
+        setupTextViewDelegate()
     }
     
     required init?(coder: NSCoder) {
@@ -57,7 +64,7 @@ final class PostContentView: UIView {
 
 extension PostContentView {
     private func setupUI() {
-        self.addSubviews(userInfoLabel,contentLabel)
+        self.addSubviews(userInfoLabel,contentTextView)
     }
     
     private func setupConstraints() {
@@ -66,53 +73,17 @@ extension PostContentView {
             $0.leading.equalToSuperview().inset(16)
         }
         
-        contentLabel.snp.makeConstraints {
+        contentTextView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.top.equalTo(userInfoLabel.snp.bottom).offset(8)
             $0.bottom.equalToSuperview()
         }
     }
     
-    private func setupGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
+    private func setupTextViewDelegate() {
+          contentTextView.delegate = self
+      }
         
-        contentLabel.addGestureRecognizer(tapGesture)
-        
-        print("제스처 추가됨")
-            print("contentLabel isUserInteractionEnabled: \(contentLabel.isUserInteractionEnabled)")
-    }
-    
-    @objc
-    func labelTapped(_ gesture: UITapGestureRecognizer) {
-        let location = gesture.location(in: contentLabel)
-        print("🔥 레이블 터치됨!")
-        if !isExpanded {
-            let labelWidth = contentLabel.bounds.width
-            let labelHeight = contentLabel.bounds.height
-            
-            if location.x > labelWidth * 0.75 && location.y > labelHeight * 0.75 {
-                toggleExpansion()
-            }
-        } else {
-            if checkIfTappedCollapseArea(location: location) {
-                toggleExpansion()
-            }
-        }
-    }
-    
-    private func checkIfTappedCollapseArea(location: CGPoint) -> Bool {
-        guard let attributedText = contentLabel.attributedText else {return false}
-        
-        let textLength = attributedText.length
-        let collapseText = " 접기"
-        let collapseRange = NSRange(location: textLength - collapseText.count, length: collapseText.count)
-        
-        let labelWidth = contentLabel.bounds.width
-        let labelHeight = contentLabel.bounds.height
-        
-        return location.x > labelWidth * 0.8 && location.y > labelHeight * 0.8
-    }
-    
     private func toggleExpansion() {
         print("토글 실행! isExpanded: \(isExpanded) -> \(!isExpanded)")
         isExpanded.toggle()
@@ -121,9 +92,6 @@ extension PostContentView {
     
     func configure(text: String) {
         fullText = text
-        contentLabel.numberOfLines = 2
-        contentLabel.attributedText = nil
-        self.contentLabel.text = text
         isExpanded = false
         
         DispatchQueue.main.async {
@@ -131,44 +99,90 @@ extension PostContentView {
         }
     }
     
-    func updateContentDisplay() {
+    private func updateContentDisplay() {
         print("updateContentDisplay 호출, isExpanded: \(isExpanded), fullText 길이: \(fullText.count)")
+        
         guard fullText.count > maxCharacterCount else {
-            contentLabel.text = fullText
-            contentLabel.numberOfLines = 0
+            contentTextView.textContainer.maximumNumberOfLines = 0
+            contentTextView.text = fullText
+            contentTextView.linkTextAttributes = [:]
             return
         }
         
         if !isExpanded {
             print("축약 모드")
-            contentLabel.numberOfLines = 2
-            contentLabel.addTrailing(with: "", moreText: " ... 더보기", moreTextFont: .pretendard(.light, size: 12), moreTextColor: .gray3)
+            contentTextView.textContainer.maximumNumberOfLines = 2
+            
+            let truncatedText = createTruncatedText()
+            let attributedString = NSMutableAttributedString(string: truncatedText, attributes: [
+                NSAttributedString.Key.font: contentTextView.font ?? UIFont.systemFont(ofSize: 14)
+            ])
+            
+            // "더보기" 링크 추가
+            let moreText = " ... 더보기"
+            let moreRange = NSRange(location: truncatedText.count - moreText.count, length: moreText.count)
+            
+            attributedString.addAttributes([
+                NSAttributedString.Key.font: UIFont.pretendard(.light, size: 12),
+                NSAttributedString.Key.foregroundColor: UIColor.gray3,
+                NSAttributedString.Key.link: "more://"
+            ], range: moreRange)
+            
+            contentTextView.attributedText = attributedString
+            
         } else {
             print("확장 모드")
-            contentLabel.numberOfLines = 0
+            contentTextView.textContainer.maximumNumberOfLines = 0
+            
             let fullTextWithCollapse = fullText + " 접기"
+            let attributedString = NSMutableAttributedString(string: fullTextWithCollapse, attributes: [
+                NSAttributedString.Key.font: contentTextView.font ?? UIFont.systemFont(ofSize: 14)
+            ])
             
-            let attributedString = NSMutableAttributedString(string: fullTextWithCollapse, attributes: [NSAttributedString.Key.font: contentLabel.font as Any])
-            
+            // "접기" 링크 추가
             let collapseRange = NSRange(location: fullText.count + 1, length: 2)
             attributedString.addAttributes([
                 NSAttributedString.Key.font: UIFont.pretendard(.light, size: 12),
-                NSAttributedString.Key.foregroundColor: UIColor.gray3
+                NSAttributedString.Key.foregroundColor: UIColor.gray3,
+                NSAttributedString.Key.link: "collapse://"
             ], range: collapseRange)
             
-            contentLabel.attributedText = attributedString
-            
+            contentTextView.attributedText = attributedString
         }
+        
+        // 링크 스타일 설정
+        contentTextView.linkTextAttributes = [
+            NSAttributedString.Key.underlineStyle: 0  // 밑줄 제거
+        ]
     }
     
-    func checkIfNeededMoreButton() {
-  
-        guard let contentTextLength = self.contentLabel.text?.count else {return}
+    private func createTruncatedText() -> String {
+        let maxLength = maxCharacterCount
+        let moreText = " ... 더보기"
         
-        if contentTextLength > 60 {
-            DispatchQueue.main.async {
-                self.contentLabel.addTrailing(with: "", moreText: " ... 더보기", moreTextFont: .pretendard(.light, size: 12), moreTextColor: .gray3)
-            }
+        if fullText.count <= maxLength {
+            return fullText + moreText
         }
+        
+        let truncateLength = maxLength - moreText.count
+        let truncatedContent = String(fullText.prefix(truncateLength))
+        return truncatedContent + moreText
+    }
+}
+
+extension PostContentView: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        
+        if URL.scheme == "more" {
+            print("더보기 터치됨!")
+            toggleExpansion()
+            return false
+        } else if URL.scheme == "collapse" {
+            print("접기 터치됨!")
+            toggleExpansion()
+            return false
+        }
+        
+        return false
     }
 }

--- a/Scently/Scently/View/Social/Review/ReviewListTableViewCell.swift
+++ b/Scently/Scently/View/Social/Review/ReviewListTableViewCell.swift
@@ -16,10 +16,18 @@ final class ReviewListTableViewCell: UITableViewCell, ReuseIdentifying {
     private let ratingStackView = UIStackView()
     private let ratingValueLabel = UILabel()
     private let moreButton = UIButton()
+    private let perfumeImageView = UIImageView()
     
     private let productNameLabel = UILabel()
     private let brandLabel = UILabel()
+    private let productInfoContainerView = UIView()
+    private let leftBorderView = UIView()
     private let contentLabel = UILabel()
+    
+    private let contentTextView = UITextView()
+    private var isExpanded = false
+    private var fullText = ""
+    private let maxCharacterCount = 70
     
     private let infoLabel = UILabel()
     private let likeButton = UIButton()
@@ -31,7 +39,9 @@ final class ReviewListTableViewCell: UITableViewCell, ReuseIdentifying {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
         setupConstraints()
+        configure()
     }
+    
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -54,8 +64,12 @@ final class ReviewListTableViewCell: UITableViewCell, ReuseIdentifying {
         likeCountLabel.text = "\(review.likeCount)+"
          */
         
+        let longText = "미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼퓸미스 디올 오 드 퍼"
+        
+        configureContent(text: longText)
+        
         nicknameLabel.text = "김아무개"
-        timeLabel.text = "2분전"
+        timeLabel.text = "· 2분전"
         ratingValueLabel.text = "3"
         productNameLabel.text = "미스 디올 오 드 퍼퓸"
         brandLabel.text = "미스 디올"
@@ -63,21 +77,104 @@ final class ReviewListTableViewCell: UITableViewCell, ReuseIdentifying {
         infoLabel.text = "남자 | 34세 | 30ML구매"
         likeCountLabel.text = "999+"
     }
+    
+    private func configureContent(text: String) {
+        fullText = text
+        isExpanded = false
+        updateContentDisplay()
+    }
+    
+    private func updateContentDisplay() {
+        guard fullText.count > maxCharacterCount else {
+            contentTextView.text = fullText
+            contentTextView.textContainer.maximumNumberOfLines = 0
+            contentTextView.linkTextAttributes = [:]
+            return
+        }
+        
+        if !isExpanded {
+            // 축약 모드
+            contentTextView.textContainer.maximumNumberOfLines = 2
+            
+            let truncatedText = createTruncatedText()
+            let attributedString = NSMutableAttributedString(string: truncatedText, attributes: [
+                NSAttributedString.Key.font: contentTextView.font ?? UIFont.pretendard(.regular, size: 12)
+            ])
+            
+            let moreText = " ... 더보기"
+            let moreRange = NSRange(location: truncatedText.count - moreText.count, length: moreText.count)
+            
+            attributedString.addAttributes([
+                NSAttributedString.Key.font: UIFont.pretendard(.regular, size: 12),
+                NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                NSAttributedString.Key.link: "more://"
+            ], range: moreRange)
+            
+            contentTextView.attributedText = attributedString
+            
+        } else {
+            // 확장 모드
+            contentTextView.textContainer.maximumNumberOfLines = 0
+            
+            let fullTextWithCollapse = fullText + " 접기"
+            let attributedString = NSMutableAttributedString(string: fullTextWithCollapse, attributes: [
+                NSAttributedString.Key.font: contentTextView.font ?? UIFont.pretendard(.regular, size: 12)
+            ])
+            
+            let collapseRange = NSRange(location: fullText.count + 1, length: 2)
+            attributedString.addAttributes([
+                NSAttributedString.Key.font: UIFont.pretendard(.regular, size: 12),
+                NSAttributedString.Key.foregroundColor: UIColor.systemGray,
+                NSAttributedString.Key.link: "collapse://"
+            ], range: collapseRange)
+            
+            contentTextView.attributedText = attributedString
+        }
+        
+        contentTextView.linkTextAttributes = [NSAttributedString.Key.underlineStyle: 0]
+    }
+    
+    private func createTruncatedText() -> String {
+        let moreText = " ... 더보기"
+        let maxLength = maxCharacterCount
+        
+        if fullText.count <= maxLength {
+            return fullText + moreText
+        }
+        
+        let truncateLength = maxLength - moreText.count
+        let truncatedContent = String(fullText.prefix(truncateLength))
+        return truncatedContent + moreText
+    }
+    
+    private func toggleExpansion() {
+        isExpanded.toggle()
+        updateContentDisplay()
+        
+        // 셀 높이 업데이트를 위해 테이블뷰에 알림
+        if let tableView = superview as? UITableView {
+            tableView.beginUpdates()
+            tableView.endUpdates()
+        }
+    }
 }
 
 private extension ReviewListTableViewCell {
     func setupUI() {
         // 프로필 이미지
-        profileImageView.backgroundColor = .lightGray
-        profileImageView.layer.cornerRadius = 20
+        profileImageView.backgroundColor = .lightgray
+        profileImageView.layer.cornerRadius = 18
         profileImageView.clipsToBounds = true
         
         // 닉네임
-        nicknameLabel.font = .systemFont(ofSize: 14, weight: .semibold)
+        nicknameLabel.font = .pretendard(.medium, size: 12)
+        nicknameLabel.textColor = .black
+        nicknameLabel.numberOfLines = 1
         
         // 시간
-        timeLabel.font = .systemFont(ofSize: 12)
-        timeLabel.textColor = .gray
+        timeLabel.font = .pretendard(.regular, size: 10)
+        timeLabel.textColor = .gray3
+//        timeLabel.numberOfLines = 1
         
         // 별점
         ratingStackView.axis = .horizontal
@@ -90,22 +187,38 @@ private extension ReviewListTableViewCell {
         }
         
         // 평점 숫자
-        ratingValueLabel.font = .systemFont(ofSize: 14)
+        ratingValueLabel.font = .pretendard(.bold, size: 10)
+        ratingValueLabel.textColor = .black
         
         // 더보기
-        moreButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
-        moreButton.tintColor = .black
+        moreButton.setImage(UIImage(named: "icon-more"), for: .normal)
+//        moreButton.tintColor = .black
+        
+        perfumeImageView.image = UIImage(named: "perfume")
         
         // 향수 이름
-        productNameLabel.font = .boldSystemFont(ofSize: 16)
+        productNameLabel.font = .pretendard(.bold, size: 14)
+        productNameLabel.textColor = .black
         
         // 브랜드
-        brandLabel.font = .systemFont(ofSize: 12)
-        brandLabel.textColor = .gray
+        brandLabel.font = .pretendard(.light, size: 10)
+        brandLabel.textColor = .gray3
         
         // 내용
-        contentLabel.font = .systemFont(ofSize: 14)
+        contentLabel.font = .pretendard(.regular, size: 12)
         contentLabel.numberOfLines = 2
+        contentLabel.textColor = .black
+        
+        contentTextView.font = .pretendard(.regular, size: 12)
+        contentTextView.textColor = .black
+        contentTextView.backgroundColor = .clear
+        contentTextView.isEditable = false
+        contentTextView.isScrollEnabled = false
+        contentTextView.textContainer.lineFragmentPadding = 0
+        contentTextView.textContainerInset = .zero
+        contentTextView.textContainer.lineBreakMode = .byCharWrapping
+        contentTextView.textContainer.maximumNumberOfLines = 3
+        contentTextView.delegate = self
         
         // 성별/연령/용량
         infoLabel.font = .systemFont(ofSize: 13)
@@ -116,21 +229,24 @@ private extension ReviewListTableViewCell {
         likeButton.tintColor = .black
         likeCountLabel.font = .systemFont(ofSize: 13)
         
+        productInfoContainerView.addSubviews(leftBorderView,productNameLabel,brandLabel)
+        
         contentView.addSubviews(
             profileImageView, nicknameLabel, timeLabel, ratingStackView, ratingValueLabel,
-            moreButton, productNameLabel, brandLabel, contentLabel,
-            infoLabel, likeButton, likeCountLabel
+            moreButton, productInfoContainerView, contentLabel,
+            infoLabel, likeButton, likeCountLabel,perfumeImageView,contentTextView
         )
     }
     
     func setupConstraints() {
+        
         profileImageView.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(16)
-            $0.size.equalTo(40)
+            $0.size.equalTo(36)
         }
         
         nicknameLabel.snp.makeConstraints {
-            $0.top.equalTo(profileImageView)
+            $0.top.equalTo(profileImageView).offset(4)
             $0.leading.equalTo(profileImageView.snp.trailing).offset(8)
         }
         
@@ -145,6 +261,12 @@ private extension ReviewListTableViewCell {
             $0.size.equalTo(24)
         }
         
+        perfumeImageView.snp.makeConstraints {
+            $0.size.equalTo(72)
+            $0.top.equalTo(profileImageView.snp.bottom).offset(12)
+            $0.trailing.equalToSuperview().offset(-16)
+        }
+        
         ratingStackView.snp.makeConstraints {
             $0.leading.equalTo(nicknameLabel)
             $0.top.equalTo(nicknameLabel.snp.bottom).offset(4)
@@ -155,30 +277,51 @@ private extension ReviewListTableViewCell {
             $0.leading.equalTo(ratingStackView.snp.trailing).offset(4)
         }
         
-        productNameLabel.snp.makeConstraints {
-            $0.top.equalTo(ratingStackView.snp.bottom).offset(12)
+        productInfoContainerView.snp.makeConstraints {
+            $0.top.equalTo(profileImageView.snp.bottom).offset(12)
             $0.leading.equalToSuperview().inset(16)
+            $0.trailing.equalTo(perfumeImageView.snp.leading).offset(-8)
+            $0.height.equalTo(28)
+        }
+        
+        productInfoContainerView.backgroundColor = .lightgray
+        productInfoContainerView.layer.cornerRadius = 6
+        
+        leftBorderView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalToSuperview()
+            $0.width.equalTo(2)
+        }
+        
+        leftBorderView.backgroundColor = .black
+        
+        productNameLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(8)
         }
         
         brandLabel.snp.makeConstraints {
             $0.centerY.equalTo(productNameLabel)
             $0.leading.equalTo(productNameLabel.snp.trailing).offset(6)
         }
-        
-        contentLabel.snp.makeConstraints {
-            $0.top.equalTo(productNameLabel.snp.bottom).offset(8)
-            $0.leading.trailing.equalToSuperview().inset(16)
+     
+        contentTextView.snp.makeConstraints {
+            $0.top.equalTo(productInfoContainerView.snp.bottom).offset(8)
+            $0.leading.equalToSuperview().inset(16)
+            $0.trailing.lessThanOrEqualTo(perfumeImageView.snp.leading).offset(-8)
         }
-        
+
+        selectionStyle = .none
+
         infoLabel.snp.makeConstraints {
-            $0.top.equalTo(contentLabel.snp.bottom).offset(12)
+            $0.top.equalTo(contentTextView.snp.bottom).offset(12)
             $0.leading.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview().inset(12)
         }
         
         likeButton.snp.makeConstraints {
             $0.centerY.equalTo(infoLabel)
-            $0.trailing.equalToSuperview().inset(40)
+            $0.trailing.equalToSuperview().inset(56)
             $0.size.equalTo(20)
         }
         
@@ -186,5 +329,20 @@ private extension ReviewListTableViewCell {
             $0.centerY.equalTo(likeButton)
             $0.leading.equalTo(likeButton.snp.trailing).offset(4)
         }
+    }
+}
+
+extension ReviewListTableViewCell: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        
+        if URL.scheme == "more" {
+            toggleExpansion()
+            return false
+        } else if URL.scheme == "collapse" {
+            toggleExpansion()
+            return false
+        }
+        
+        return false
     }
 }


### PR DESCRIPTION
## 1. 요약 

- 리뷰 리스트 셀 UI 작업 

## 2. 스크린샷 

![Simulator Screen Recording - iPhone 16 Pro - 2025-08-16 at 17 54 03](https://github.com/user-attachments/assets/59bea800-e681-46e0-8665-03ac4dd7ec9b)



## 3. 공유사항

- 시연님께서 작업 해주신 내용 바탕으로 피그마  상 디자인에 맞춰 몇가지 수정했습니다.
-  더보기/ 접기 눌렀을때 UI 관련해서 기존 피그마 상에서는 이미지 하단 전부 텍스트가 늘어나도록 되어있는데 아직 이부분은 구현하지 못했습니다.
ㄴ  textView 를 2개를 만들어서 특정 글자까지는 처음 보여주다가 더보기를 누르면 2번째 textView에 나머지 부분 영역을 추가해서 구현을 해야할지 아니면 어떻게 해야할지 고민중인데 혹시 이부분 관련해서 괜찮은 아이디어가 있을까요?
ㄴ 만약 이 부분 구현이 어려우면 현재 구현 방식으로 디자인 수정 건의 드려봐야 할 것 같습니다...
