### PR TITLE
[Feat] 자유게시글 API 구현

### DIFF
--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -1,0 +1,49 @@
+//
+//  FreeBoardRepository.swift
+//  Scently
+//
+//  Created by 임재현 on 9/7/25.
+//
+
+import Foundation
+import Moya
+import Combine
+
+protocol FreeBoardRepositoryProtocol {
+    func getFreeBoardList(order: String, page:Int, size: Int) -> AnyPublisher<FreeBoardListData,Error>
+}
+
+
+class FreeBoardRepository: FreeBoardRepositoryProtocol {
+   
+    private let networkService: NetworkService<FreeBoardTarget>
+    
+    init(networkService: NetworkService<FreeBoardTarget> = NetworkService<FreeBoardTarget>()) {
+        self.networkService = networkService
+    }
+    
+    
+    func getFreeBoardList(order: String, page: Int, size: Int) -> AnyPublisher<FreeBoardListData,Error> {
+        return networkService.request(.getFreeBoardList(order: order, page: page, size: size), responseType: FreeBoardListResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                return response.data ?? FreeBoardListData(dataList: [], pageInfo: PageInfo(page: 0, size: 0, totalElements: 0, totalPages: 0))
+            }
+            .handleEvents(receiveOutput: { ootdListData in
+                print("Successfully loaded \(ootdListData.dataList.count) OOTDs")
+            })
+            .catch { error -> AnyPublisher<FreeBoardListData, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to load OOTD list: \(networkError.errorDescription ?? "")")
+                } else {
+                    print("Failed to load OOTD list: \(error.localizedDescription)")
+                }
+                return Just(FreeBoardListData(dataList: [], pageInfo: PageInfo(page: 0, size: 0, totalElements: 0, totalPages: 0)))
+                    .setFailureType(to: Error.self)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+        }
+    }

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -17,6 +17,7 @@ protocol FreeBoardRepositoryProtocol {
     func getDetailFreeBoard(postID: Int) -> AnyPublisher<FreeBoardDetailData, Error>
     
     func deleteFreeBoard(postId: Int) -> AnyPublisher<DeleteFreeBoardResponse, Error>
+    func likeFreeBoard(postId: Int) -> AnyPublisher<LikeFreeBoardResponse, Error>
 }
 
 
@@ -132,6 +133,44 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
     
     func deleteFreeBoard(postId: Int) -> AnyPublisher<DeleteFreeBoardResponse, any Error> {
         return networkService.request(.deleteFreeBoard(postId: postId), responseType: DeleteFreeBoardResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                return response
+            }
+            .handleEvents(receiveOutput: { response in
+                print("Successfully deleted post with ID: \(postId)")
+                print("Server message: \(response.message)")
+            })
+            .catch { error -> AnyPublisher<DeleteFreeBoardResponse, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to delete post: \(networkError.errorDescription ?? "")")
+                    
+                    switch networkError {
+                    case .onlyAuthorCanDelete:
+                        print("Only author can delete this post")
+                    case .ootdNotFound, .ootdAlreadyDeleted:
+                        print("Post not found or already deleted")
+                    case .invalidToken, .expiredToken:
+                        print("Token error - need to re-login")
+                    case .internalServerError:
+                        print("Server error - please try again later")
+                    default:
+                        break
+                    }
+                } else {
+                    print("Failed to delete post: \(error.localizedDescription)")
+                }
+    
+                return Fail(error: error)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func likeFreeBoard(postId: Int) -> AnyPublisher<LikeFreeBoardResponse, any Error> {
+        return networkService.request(.deleteFreeBoard(postId: postId), responseType: LikeFreeBoardResponse.self)
             .tryMap { response in
                 if !response.success {
                     throw response.networkError ?? NetworkError.unknownError

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -11,6 +11,8 @@ import Combine
 
 protocol FreeBoardRepositoryProtocol {
     func getFreeBoardList(order: String, page:Int, size: Int) -> AnyPublisher<FreeBoardListData,Error>
+    
+    func postFreeBoard(title: String, content: String, tagNames: [String]) -> AnyPublisher<CreatedPostData, Error>
 }
 
 
@@ -46,4 +48,42 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
             }
             .eraseToAnyPublisher()
         }
+    
+    func postFreeBoard(title: String, content: String, tagNames: [String]) -> AnyPublisher<CreatedPostData, any Error> {
+        return networkService.request(.postFreeBoard(title: title, content: content, tagNames: tagNames), responseType: CreatePostResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                guard let data = response.data else {
+                    throw NetworkError.unknownError
+                }
+                return data
+            }
+            .handleEvents(receiveOutput: { createdPost in
+                print("Successfully created post with ID: \(createdPost)")
+            })
+            .catch { error -> AnyPublisher<CreatedPostData, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to create post: \(networkError.errorDescription ?? "")")
+                    
+                    switch networkError {
+                    case .invalidToken, .expiredToken:
+                        // 토큰 관련 에러 - 로그인 화면으로 이동 등
+                        break
+                    case .internalServerError:
+                        // 서버 에러 - 재시도 유도
+                        break
+                    default:
+                        break
+                    }
+                } else {
+                    print("Failed to create post: \(error.localizedDescription)")
+                }
+                return Just(CreatedPostData(postId: 0))
+                    .setFailureType(to: Error.self)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
     }
+}

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -21,6 +21,8 @@ protocol FreeBoardRepositoryProtocol {
     func getFreeBoardComments(postId: Int) -> AnyPublisher<FreeBoardCommentsData, Error>
     func postFreeBoardComment(postId: Int, commentId:Int?, comment: String)  -> AnyPublisher<FreeBoardCommentData, Error>
     func likeFreeBoardComment(postId: Int, commentId: Int) -> AnyPublisher<LikeFreeBoardCommentResponse, Error>
+    
+    func deleteFreeBoardComment(postId: Int, commentId: Int) -> AnyPublisher<DeleteFreeBoardCommentResponse, Error>
 }
 
 
@@ -328,4 +330,43 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
             }
             .eraseToAnyPublisher()
     }
+    
+    func deleteFreeBoardComment(postId: Int, commentId: Int) -> AnyPublisher<DeleteFreeBoardCommentResponse, any Error> {
+        return networkService.request(.deleteFreeBoardComment(postId: postId, commentId: commentId), responseType: DeleteFreeBoardCommentResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                return response
+            }
+            .handleEvents(receiveOutput: { response in
+                print("Successfully deleted comment ID: \(commentId) from post ID: \(postId)")
+                print("Server message: \(response.message)")
+            })
+            .catch { error -> AnyPublisher<DeleteFreeBoardCommentResponse, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to delete comment: \(networkError.errorDescription ?? "")")
+                    
+                    switch networkError {
+                    case .onlyAuthorCanDelete:
+                        print("Only comment author can delete this comment")
+                    case .ootdNotFound, .ootdAlreadyDeleted:
+                        print("Comment not found or already deleted")
+                    case .invalidToken, .expiredToken:
+                        print("Token error - need to re-login")
+                    case .internalServerError:
+                        print("Server error - please try again later")
+                    default:
+                        break
+                    }
+                } else {
+                    print("Failed to delete comment: \(error.localizedDescription)")
+                }
+                
+                return Fail(error: error)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+    
 }

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -13,6 +13,8 @@ protocol FreeBoardRepositoryProtocol {
     func getFreeBoardList(order: String, page:Int, size: Int) -> AnyPublisher<FreeBoardListData,Error>
     
     func postFreeBoard(title: String, content: String, tagNames: [String]) -> AnyPublisher<CreatedPostData, Error>
+    
+    func getDetailFreeBoard(postID: Int) -> AnyPublisher<FreeBoardDetailResponse, Error>
 }
 
 
@@ -85,5 +87,44 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
                     .eraseToAnyPublisher()
             }
             .eraseToAnyPublisher()
+    }
+    
+    func getDetailFreeBoard(postID: Int) -> AnyPublisher<FreeBoardDetailData, any Error> {
+       return networkService.request(.getDetailFreeBoard(postID: postID), responseType: FreeBoardDetailResponse.self)
+           .tryMap { response in
+               if !response.success {
+                   throw response.networkError ?? NetworkError.unknownError
+               }
+               guard let data = response.data else {
+                   throw NetworkError.unknownError
+               }
+               return data
+           }
+           .handleEvents(receiveOutput: { detailData in
+               print("Successfully loaded post detail: \(detailData.postInfo.title)")
+           })
+           .catch { error -> AnyPublisher<FreeBoardDetailData, Error> in
+               if let networkError = error as? NetworkError {
+                   print("Failed to load post detail: \(networkError.errorDescription ?? "")")
+                   
+                   switch networkError {
+                   case .invalidToken, .expiredToken:
+                       // 토큰 관련 에러 처리
+                       break
+                   case .internalServerError:
+                       // 서버 에러 처리
+                       break
+
+                   default:
+                       break
+                   }
+               } else {
+                   print("Failed to load post detail: \(error.localizedDescription)")
+               }
+               
+               return Fail(error: error)
+                   .eraseToAnyPublisher()
+           }
+           .eraseToAnyPublisher()
     }
 }

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -18,6 +18,7 @@ protocol FreeBoardRepositoryProtocol {
     
     func deleteFreeBoard(postId: Int) -> AnyPublisher<DeleteFreeBoardResponse, Error>
     func likeFreeBoard(postId: Int) -> AnyPublisher<LikeFreeBoardResponse, Error>
+    func getFreeBoardComments(postId: Int) -> AnyPublisher<FreeBoardCommentsData, Error>
 }
 
 
@@ -206,4 +207,44 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
             }
             .eraseToAnyPublisher()
     }
+    
+    func getFreeBoardComments(postId: Int) -> AnyPublisher<FreeBoardCommentsData, any Error> {
+        return networkService.request(.getFreeBoardComments(postId: postId), responseType: FreeBoardCommentsResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                guard let data = response.data else {
+                    throw NetworkError.unknownError
+                }
+                return data
+            }
+            .handleEvents(receiveOutput: { commentsData in
+                print("Successfully loaded \(commentsData.totalCommentCount) total comments")
+                print("Parent comments: \(commentsData.commentInfos.count)")
+            })
+            .catch { error -> AnyPublisher<FreeBoardCommentsData, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to load comments: \(networkError.errorDescription ?? "")")
+                    
+                    switch networkError {
+                    case .ootdNotFound:
+                        print("Post not found")
+                    case .invalidToken, .expiredToken:
+                        print("Token error - need to re-login")
+                    case .internalServerError:
+                        print("Server error - please try again later")
+                    default:
+                        break
+                    }
+                } else {
+                    print("Failed to load comments: \(error.localizedDescription)")
+                }
+        
+                return Fail(error: error)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+    
 }

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -20,6 +20,7 @@ protocol FreeBoardRepositoryProtocol {
     func likeFreeBoard(postId: Int) -> AnyPublisher<LikeFreeBoardResponse, Error>
     func getFreeBoardComments(postId: Int) -> AnyPublisher<FreeBoardCommentsData, Error>
     func postFreeBoardComment(postId: Int, commentId:Int?, comment: String)  -> AnyPublisher<FreeBoardCommentData, Error>
+    func likeFreeBoardComment(postId: Int, commentId: Int) -> AnyPublisher<LikeFreeBoardCommentResponse, Error>
 }
 
 
@@ -284,6 +285,42 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
                     }
                 } else {
                     print("Failed to create comment: \(error.localizedDescription)")
+                }
+                
+                return Fail(error: error)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func likeFreeBoardComment(postId: Int, commentId: Int) -> AnyPublisher<LikeFreeBoardCommentResponse, any Error> {
+        return networkService.request(.likeFreeBoardComment(postId: postId, commentId: commentId), responseType: LikeFreeBoardCommentResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                return response
+            }
+            .handleEvents(receiveOutput: { response in
+                print("Successfully liked comment ID: \(commentId) in post ID: \(postId)")
+                print("Server message: \(response.message)")
+            })
+            .catch { error -> AnyPublisher<LikeFreeBoardCommentResponse, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to like comment: \(networkError.errorDescription ?? "")")
+                    
+                    switch networkError {
+                    case .ootdNotFound:
+                        print("Post or comment not found")
+                    case .invalidToken, .expiredToken:
+                        print("Token error - need to re-login")
+                    case .internalServerError:
+                        print("Server error - please try again later")
+                    default:
+                        break
+                    }
+                } else {
+                    print("Failed to like comment: \(error.localizedDescription)")
                 }
                 
                 return Fail(error: error)

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -19,6 +19,7 @@ protocol FreeBoardRepositoryProtocol {
     func deleteFreeBoard(postId: Int) -> AnyPublisher<DeleteFreeBoardResponse, Error>
     func likeFreeBoard(postId: Int) -> AnyPublisher<LikeFreeBoardResponse, Error>
     func getFreeBoardComments(postId: Int) -> AnyPublisher<FreeBoardCommentsData, Error>
+    func postFreeBoardComment(postId: Int, commentId:Int?, comment: String)  -> AnyPublisher<FreeBoardCommentData, Error>
 }
 
 
@@ -247,4 +248,47 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
             .eraseToAnyPublisher()
     }
     
+    
+    func postFreeBoardComment(postId: Int, commentId: Int?, comment: String) -> AnyPublisher<FreeBoardCommentData, any Error> {
+        return networkService.request(.postFreeBoardComment(postId: postId, commentId: commentId, comment: comment), responseType: PostFreeBoardCommentResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                guard let data = response.data else {
+                    throw NetworkError.unknownError
+                }
+                return data
+            }
+            .handleEvents(receiveOutput: { commentData in
+                if let commentId = commentId {
+                    print("Successfully created reply comment for parent ID: \(commentId)")
+                } else {
+                    print("Successfully created new comment for post ID: \(postId)")
+                }
+                print("Created comment ID: \(commentData.commentId)")
+            })
+            .catch { error -> AnyPublisher<FreeBoardCommentData, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to create comment: \(networkError.errorDescription ?? "")")
+                    
+                    switch networkError {
+                    case .ootdNotFound:
+                        print("Post not found")
+                    case .invalidToken, .expiredToken:
+                        print("Token error - need to re-login")
+                    case .internalServerError:
+                        print("Server error - please try again later")
+                    default:
+                        break
+                    }
+                } else {
+                    print("Failed to create comment: \(error.localizedDescription)")
+                }
+                
+                return Fail(error: error)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
 }

--- a/Scently/Scently/API/Core/FreeBoardRepository.swift
+++ b/Scently/Scently/API/Core/FreeBoardRepository.swift
@@ -14,7 +14,9 @@ protocol FreeBoardRepositoryProtocol {
     
     func postFreeBoard(title: String, content: String, tagNames: [String]) -> AnyPublisher<CreatedPostData, Error>
     
-    func getDetailFreeBoard(postID: Int) -> AnyPublisher<FreeBoardDetailResponse, Error>
+    func getDetailFreeBoard(postID: Int) -> AnyPublisher<FreeBoardDetailData, Error>
+    
+    func deleteFreeBoard(postId: Int) -> AnyPublisher<DeleteFreeBoardResponse, Error>
 }
 
 
@@ -89,7 +91,7 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
             .eraseToAnyPublisher()
     }
     
-    func getDetailFreeBoard(postID: Int) -> AnyPublisher<FreeBoardDetailData, any Error> {
+    func getDetailFreeBoard(postID: Int) -> AnyPublisher<FreeBoardDetailData, Error> {
        return networkService.request(.getDetailFreeBoard(postID: postID), responseType: FreeBoardDetailResponse.self)
            .tryMap { response in
                if !response.success {
@@ -126,5 +128,43 @@ class FreeBoardRepository: FreeBoardRepositoryProtocol {
                    .eraseToAnyPublisher()
            }
            .eraseToAnyPublisher()
+    }
+    
+    func deleteFreeBoard(postId: Int) -> AnyPublisher<DeleteFreeBoardResponse, any Error> {
+        return networkService.request(.deleteFreeBoard(postId: postId), responseType: DeleteFreeBoardResponse.self)
+            .tryMap { response in
+                if !response.success {
+                    throw response.networkError ?? NetworkError.unknownError
+                }
+                return response
+            }
+            .handleEvents(receiveOutput: { response in
+                print("Successfully deleted post with ID: \(postId)")
+                print("Server message: \(response.message)")
+            })
+            .catch { error -> AnyPublisher<DeleteFreeBoardResponse, Error> in
+                if let networkError = error as? NetworkError {
+                    print("Failed to delete post: \(networkError.errorDescription ?? "")")
+                    
+                    switch networkError {
+                    case .onlyAuthorCanDelete:
+                        print("Only author can delete this post")
+                    case .ootdNotFound, .ootdAlreadyDeleted:
+                        print("Post not found or already deleted")
+                    case .invalidToken, .expiredToken:
+                        print("Token error - need to re-login")
+                    case .internalServerError:
+                        print("Server error - please try again later")
+                    default:
+                        break
+                    }
+                } else {
+                    print("Failed to delete post: \(error.localizedDescription)")
+                }
+    
+                return Fail(error: error)
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
     }
 }

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -11,6 +11,7 @@ import Moya
 enum FreeBoardTarget {
     case getFreeBoardList(order: String, page:Int, size: Int)
     case postFreeBoard(title: String, content: String, tagNames: [String])
+    case getDetailFreeBoard(postID: Int)
 }
 
 extension FreeBoardTarget: TargetType {
@@ -28,12 +29,14 @@ extension FreeBoardTarget: TargetType {
             return "/api/v1/posts"
         case .postFreeBoard:
             return "/api/v1/posts"
+        case .getDetailFreeBoard(let postId):
+            return "/api/v1/posts/\(postId)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getFreeBoardList:
+        case .getFreeBoardList, .getDetailFreeBoard:
             return .get
         case .postFreeBoard:
             return .post
@@ -54,6 +57,8 @@ extension FreeBoardTarget: TargetType {
         case .postFreeBoard(let title, let content, let tagNames):
             let requestBody = CreateFreeBoardPostRequest(title: title, content: content, tagNames: tagNames)
             return .requestJSONEncodable(requestBody)
+        case .getDetailFreeBoard:
+            return .requestPlain
         }
     }
     

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -17,6 +17,7 @@ enum FreeBoardTarget {
     case getFreeBoardComments(postId: Int)
     case postFreeBoardComment(postId: Int, commentId:Int?, comment: String)
     case likeFreeBoardComment(postId: Int, commentId: Int)
+    case deleteFreeBoardComment(postId: Int, commentId: Int)
 }
 
 extension FreeBoardTarget: TargetType {
@@ -46,6 +47,8 @@ extension FreeBoardTarget: TargetType {
             return "/api/v1/posts/\(postId)/comments"
         case .likeFreeBoardComment( let postId, let commentId):
             return "/api/v1/posts/\(postId)/comments/\(commentId)/like"
+        case .deleteFreeBoardComment(let postId, let commentId):
+            return "/api/v1/posts/\(postId)/comments/\(commentId)"
         }
     }
     
@@ -55,7 +58,7 @@ extension FreeBoardTarget: TargetType {
             return .get
         case .postFreeBoard,.likeFreeBoardPost, .postFreeBoardComment,.likeFreeBoardComment :
             return .post
-        case .deleteFreeBoard:
+        case .deleteFreeBoard, .deleteFreeBoardComment:
             return .delete
         }
     }
@@ -74,7 +77,7 @@ extension FreeBoardTarget: TargetType {
         case .postFreeBoard(let title, let content, let tagNames):
             let requestBody = CreateFreeBoardPostRequest(title: title, content: content, tagNames: tagNames)
             return .requestJSONEncodable(requestBody)
-        case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost, .getFreeBoardComments, .likeFreeBoardComment:
+        case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost, .getFreeBoardComments, .likeFreeBoardComment, .deleteFreeBoardComment:
             return .requestPlain
         case .postFreeBoardComment(let postId, let commentId, let comment):
             let requestBody = CreateFreeBoardCommentRequest(commentId: commentId, comment: comment)

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -15,6 +15,7 @@ enum FreeBoardTarget {
     case deleteFreeBoard(postId: Int)
     case likeFreeBoardPost(postId: Int)
     case getFreeBoardComments(postId: Int)
+    case postFreeBoardComment(postId: Int, commentId:Int?, comment: String)
 }
 
 extension FreeBoardTarget: TargetType {
@@ -40,6 +41,8 @@ extension FreeBoardTarget: TargetType {
             return "/api/v1/posts/\(postId)"
         case .getFreeBoardComments(let postId):
             return "/api/v1/posts/\(postId)/comments"
+        case .postFreeBoardComment(let postId, _, _):
+            return "/api/v1/posts/\(postId)/comments"
         }
     }
     
@@ -47,7 +50,7 @@ extension FreeBoardTarget: TargetType {
         switch self {
         case .getFreeBoardList, .getDetailFreeBoard,.getFreeBoardComments:
             return .get
-        case .postFreeBoard,.likeFreeBoardPost:
+        case .postFreeBoard,.likeFreeBoardPost, .postFreeBoardComment:
             return .post
         case .deleteFreeBoard:
             return .delete
@@ -70,6 +73,10 @@ extension FreeBoardTarget: TargetType {
             return .requestJSONEncodable(requestBody)
         case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost, .getFreeBoardComments:
             return .requestPlain
+        case .postFreeBoardComment(let postId, let commentId, let comment):
+            let requestBody = CreateFreeBoardCommentRequest(commentId: commentId, comment: comment)
+            return .requestJSONEncodable(requestBody)
+
         }
     }
     

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -14,6 +14,7 @@ enum FreeBoardTarget {
     case getDetailFreeBoard(postID: Int)
     case deleteFreeBoard(postId: Int)
     case likeFreeBoardPost(postId: Int)
+    case getFreeBoardComments(postId: Int)
 }
 
 extension FreeBoardTarget: TargetType {
@@ -37,12 +38,14 @@ extension FreeBoardTarget: TargetType {
             return "/api/v1/posts/\(postId)"
         case .likeFreeBoardPost(let postId):
             return "/api/v1/posts/\(postId)"
+        case .getFreeBoardComments(let postId):
+            return "/api/v1/posts/\(postId)/comments"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getFreeBoardList, .getDetailFreeBoard:
+        case .getFreeBoardList, .getDetailFreeBoard,.getFreeBoardComments:
             return .get
         case .postFreeBoard,.likeFreeBoardPost:
             return .post
@@ -65,7 +68,7 @@ extension FreeBoardTarget: TargetType {
         case .postFreeBoard(let title, let content, let tagNames):
             let requestBody = CreateFreeBoardPostRequest(title: title, content: content, tagNames: tagNames)
             return .requestJSONEncodable(requestBody)
-        case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost:
+        case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost, .getFreeBoardComments:
             return .requestPlain
         }
     }

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -16,6 +16,7 @@ enum FreeBoardTarget {
     case likeFreeBoardPost(postId: Int)
     case getFreeBoardComments(postId: Int)
     case postFreeBoardComment(postId: Int, commentId:Int?, comment: String)
+    case likeFreeBoardComment(postId: Int, commentId: Int)
 }
 
 extension FreeBoardTarget: TargetType {
@@ -43,6 +44,8 @@ extension FreeBoardTarget: TargetType {
             return "/api/v1/posts/\(postId)/comments"
         case .postFreeBoardComment(let postId, _, _):
             return "/api/v1/posts/\(postId)/comments"
+        case .likeFreeBoardComment( let postId, let commentId):
+            return "/api/v1/posts/\(postId)/comments/\(commentId)/like"
         }
     }
     
@@ -50,7 +53,7 @@ extension FreeBoardTarget: TargetType {
         switch self {
         case .getFreeBoardList, .getDetailFreeBoard,.getFreeBoardComments:
             return .get
-        case .postFreeBoard,.likeFreeBoardPost, .postFreeBoardComment:
+        case .postFreeBoard,.likeFreeBoardPost, .postFreeBoardComment,.likeFreeBoardComment :
             return .post
         case .deleteFreeBoard:
             return .delete
@@ -71,7 +74,7 @@ extension FreeBoardTarget: TargetType {
         case .postFreeBoard(let title, let content, let tagNames):
             let requestBody = CreateFreeBoardPostRequest(title: title, content: content, tagNames: tagNames)
             return .requestJSONEncodable(requestBody)
-        case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost, .getFreeBoardComments:
+        case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost, .getFreeBoardComments, .likeFreeBoardComment:
             return .requestPlain
         case .postFreeBoardComment(let postId, let commentId, let comment):
             let requestBody = CreateFreeBoardCommentRequest(commentId: commentId, comment: comment)

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum FreeBoardTarget {
     case getFreeBoardList(order: String, page:Int, size: Int)
+    case postFreeBoard(title: String, content: String, tagNames: [String])
 }
 
 extension FreeBoardTarget: TargetType {
@@ -25,6 +26,8 @@ extension FreeBoardTarget: TargetType {
         switch self {
         case .getFreeBoardList:
             return "/api/v1/posts"
+        case .postFreeBoard:
+            return "/api/v1/posts"
         }
     }
     
@@ -32,6 +35,8 @@ extension FreeBoardTarget: TargetType {
         switch self {
         case .getFreeBoardList:
             return .get
+        case .postFreeBoard:
+            return .post
         }
     }
     
@@ -46,6 +51,9 @@ extension FreeBoardTarget: TargetType {
                 ],
                 encoding: URLEncoding.queryString
             )
+        case .postFreeBoard(let title, let content, let tagNames):
+            let requestBody = CreateFreeBoardPostRequest(title: title, content: content, tagNames: tagNames)
+            return .requestJSONEncodable(requestBody)
         }
     }
     

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -13,6 +13,7 @@ enum FreeBoardTarget {
     case postFreeBoard(title: String, content: String, tagNames: [String])
     case getDetailFreeBoard(postID: Int)
     case deleteFreeBoard(postId: Int)
+    case likeFreeBoardPost(postId: Int)
 }
 
 extension FreeBoardTarget: TargetType {
@@ -34,6 +35,8 @@ extension FreeBoardTarget: TargetType {
             return "/api/v1/posts/\(postId)"
         case .deleteFreeBoard(let postId):
             return "/api/v1/posts/\(postId)"
+        case .likeFreeBoardPost(let postId):
+            return "/api/v1/posts/\(postId)"
         }
     }
     
@@ -41,7 +44,7 @@ extension FreeBoardTarget: TargetType {
         switch self {
         case .getFreeBoardList, .getDetailFreeBoard:
             return .get
-        case .postFreeBoard:
+        case .postFreeBoard,.likeFreeBoardPost:
             return .post
         case .deleteFreeBoard:
             return .delete
@@ -62,7 +65,7 @@ extension FreeBoardTarget: TargetType {
         case .postFreeBoard(let title, let content, let tagNames):
             let requestBody = CreateFreeBoardPostRequest(title: title, content: content, tagNames: tagNames)
             return .requestJSONEncodable(requestBody)
-        case .getDetailFreeBoard, .deleteFreeBoard:
+        case .getDetailFreeBoard, .deleteFreeBoard, .likeFreeBoardPost:
             return .requestPlain
         }
     }

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -12,6 +12,7 @@ enum FreeBoardTarget {
     case getFreeBoardList(order: String, page:Int, size: Int)
     case postFreeBoard(title: String, content: String, tagNames: [String])
     case getDetailFreeBoard(postID: Int)
+    case deleteFreeBoard(postId: Int)
 }
 
 extension FreeBoardTarget: TargetType {
@@ -31,6 +32,8 @@ extension FreeBoardTarget: TargetType {
             return "/api/v1/posts"
         case .getDetailFreeBoard(let postId):
             return "/api/v1/posts/\(postId)"
+        case .deleteFreeBoard(let postId):
+            return "/api/v1/posts/\(postId)"
         }
     }
     
@@ -40,6 +43,8 @@ extension FreeBoardTarget: TargetType {
             return .get
         case .postFreeBoard:
             return .post
+        case .deleteFreeBoard:
+            return .delete
         }
     }
     
@@ -57,7 +62,7 @@ extension FreeBoardTarget: TargetType {
         case .postFreeBoard(let title, let content, let tagNames):
             let requestBody = CreateFreeBoardPostRequest(title: title, content: content, tagNames: tagNames)
             return .requestJSONEncodable(requestBody)
-        case .getDetailFreeBoard:
+        case .getDetailFreeBoard, .deleteFreeBoard:
             return .requestPlain
         }
     }

--- a/Scently/Scently/API/Core/FreeBoardTarget.swift
+++ b/Scently/Scently/API/Core/FreeBoardTarget.swift
@@ -1,0 +1,58 @@
+//
+//  FreeBoardTarget.swift
+//  Scently
+//
+//  Created by 임재현 on 9/7/25.
+//
+
+import Foundation
+import Moya
+
+enum FreeBoardTarget {
+    case getFreeBoardList(order: String, page:Int, size: Int)
+}
+
+extension FreeBoardTarget: TargetType {
+    
+    var baseURL: URL {
+        guard let url = URL(string: AppConfig.shared.baseURL) else {
+            fatalError("Invalid base URL")
+        }
+        return url
+    }
+    
+    var path: String {
+        switch self {
+        case .getFreeBoardList:
+            return "/api/v1/posts"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getFreeBoardList:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getFreeBoardList(let order, let page, let size):
+            return .requestParameters(
+                parameters: [
+                    "order": order,
+                    "page": page,
+                    "size": size
+                ],
+                encoding: URLEncoding.queryString
+            )
+        }
+    }
+    
+    var headers: [String : String]? {
+        return [
+            "Content-Type": "application/json"
+        ]
+    }
+}
+

--- a/Scently/Scently/Model/CreateFreeBoardCommentRequest.swift
+++ b/Scently/Scently/Model/CreateFreeBoardCommentRequest.swift
@@ -1,0 +1,13 @@
+//
+//  CreateFreeBoardCommentRequest.swift
+//  Scently
+//
+//  Created by 임재현 on 9/13/25.
+//
+
+import Foundation
+
+struct CreateFreeBoardCommentRequest: Codable {
+    let commentId: Int?
+    let comment: String  
+}

--- a/Scently/Scently/Model/CreateFreeBoardPostRequest.swift
+++ b/Scently/Scently/Model/CreateFreeBoardPostRequest.swift
@@ -1,0 +1,14 @@
+//
+//  CreateFreeBoardPostRequest.swift
+//  Scently
+//
+//  Created by 임재현 on 9/7/25.
+//
+
+import Foundation
+
+struct CreateFreeBoardPostRequest: Codable {
+    let title: String
+    let content: String
+    let tagNames: [String]
+}

--- a/Scently/Scently/Model/CreatePostData.swift
+++ b/Scently/Scently/Model/CreatePostData.swift
@@ -1,0 +1,14 @@
+//
+//  CreatePostData.swift
+//  Scently
+//
+//  Created by 임재현 on 9/7/25.
+//
+
+import Foundation
+
+typealias CreatePostResponse = BaseResponse<CreatedPostData>
+
+struct CreatedPostData: Codable {
+    let postId: Int
+}

--- a/Scently/Scently/Model/DeleteFreeBoardResponse.swift
+++ b/Scently/Scently/Model/DeleteFreeBoardResponse.swift
@@ -8,3 +8,4 @@
 import Foundation
 
 typealias DeleteFreeBoardResponse = BaseResponse<EmptyData>
+typealias LikeFreeBoardResponse = BaseResponse<EmptyData>

--- a/Scently/Scently/Model/DeleteFreeBoardResponse.swift
+++ b/Scently/Scently/Model/DeleteFreeBoardResponse.swift
@@ -9,3 +9,4 @@ import Foundation
 
 typealias DeleteFreeBoardResponse = BaseResponse<EmptyData>
 typealias LikeFreeBoardResponse = BaseResponse<EmptyData>
+typealias DeleteFreeBoardCommentResponse = BaseResponse<EmptyData>

--- a/Scently/Scently/Model/DeleteFreeBoardResponse.swift
+++ b/Scently/Scently/Model/DeleteFreeBoardResponse.swift
@@ -1,0 +1,10 @@
+//
+//  DeleteFreeBoardResponse.swift
+//  Scently
+//
+//  Created by 임재현 on 9/13/25.
+//
+
+import Foundation
+
+typealias DeleteFreeBoardResponse = BaseResponse<EmptyData>

--- a/Scently/Scently/Model/FreeBoardCommentResponse.swift
+++ b/Scently/Scently/Model/FreeBoardCommentResponse.swift
@@ -1,0 +1,15 @@
+//
+//  FreeBoardCommentResponse.swift
+//  Scently
+//
+//  Created by 임재현 on 9/13/25.
+//
+
+import Foundation
+
+
+typealias PostFreeBoardCommentResponse = BaseResponse<FreeBoardCommentData>
+
+struct FreeBoardCommentData: Codable {
+    let commentId: Int
+}

--- a/Scently/Scently/Model/FreeBoardCommentResponse.swift
+++ b/Scently/Scently/Model/FreeBoardCommentResponse.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 typealias PostFreeBoardCommentResponse = BaseResponse<FreeBoardCommentData>
+typealias LikeFreeBoardCommentResponse = BaseResponse<EmptyData>
 
 struct FreeBoardCommentData: Codable {
     let commentId: Int

--- a/Scently/Scently/Model/FreeBoardCommentsResponse.swift
+++ b/Scently/Scently/Model/FreeBoardCommentsResponse.swift
@@ -1,0 +1,15 @@
+//
+//  FreeBoardCommentsResponse.swift
+//  Scently
+//
+//  Created by 임재현 on 9/13/25.
+//
+
+import Foundation
+
+typealias FreeBoardCommentsResponse = BaseResponse<FreeBoardCommentsData>
+
+struct FreeBoardCommentsData: Codable {
+    let commentInfos: [CommentInfo]
+    let totalCommentCount: Int
+}

--- a/Scently/Scently/Model/FreeBoardDetailResponse.swift
+++ b/Scently/Scently/Model/FreeBoardDetailResponse.swift
@@ -6,3 +6,25 @@
 //
 
 import Foundation
+
+typealias FreeBoardDetailResponse = BaseResponse<FreeBoardDetailData>
+
+struct FreeBoardDetailData: Codable {
+   let postInfo: FreeBoardPostInfo
+   let userInfo: FreeBoardUserInfo
+}
+
+struct FreeBoardPostInfo: Codable {
+   let title: String
+   let content: String
+   let createdAt: Data
+   let likeCount: Int
+   let viewCount: Int
+   let commentCount: Int
+}
+
+struct FreeBoardUserInfo: Codable {
+   let userId: Int
+   let profileImageUrl: String
+   let nickname: String
+}

--- a/Scently/Scently/Model/FreeBoardDetailResponse.swift
+++ b/Scently/Scently/Model/FreeBoardDetailResponse.swift
@@ -1,0 +1,8 @@
+//
+//  FreeBoardDetailResponse.swift
+//  Scently
+//
+//  Created by 임재현 on 9/7/25.
+//
+
+import Foundation

--- a/Scently/Scently/Model/FreeBoardListResponse.swift
+++ b/Scently/Scently/Model/FreeBoardListResponse.swift
@@ -1,0 +1,24 @@
+//
+//  FreeBoardListResponse.swift
+//  Scently
+//
+//  Created by 임재현 on 9/7/25.
+//
+
+import Foundation
+
+typealias FreeBoardListResponse = BaseResponse<FreeBoardListData>
+
+struct FreeBoardListData: Codable {
+   let dataList: [FreePost]
+   let pageInfo: PageInfo
+}
+
+struct FreePost: Codable {
+   let postId: Int
+   let title: String
+   let content: String
+   let createdAt: Date
+   let viewCount: Int
+   let commentCount: Int
+}


### PR DESCRIPTION
## 1. 요약 
자유게시글 CRUD 관련 API 구현 완료
- [x] 자유게시글 목록 조회
- [x] 작성
- [x] 상세 조회
- [x] 삭제
- [x] 좋아요(푸시알림)
- [x] 상세 댓글 조회
- [x] 댓글 작성(푸시알림)
- [x] 자유게시글 댓글 좋아요
- [x] 자유게시글 댓글 삭제
## 2. 스크린샷 
N/A
## 3. 공유사항
